### PR TITLE
fix: final title still has `/` if the original has `:`

### DIFF
--- a/notes2html
+++ b/notes2html
@@ -373,7 +373,7 @@ if __name__ == '__main__':
         hdoc = E('html',E('head',E('style',css)),E('body',section))
         fn = id
         if use_title and title:
-            tmp = title.replace('/','_')[:64]
+            tmp = title.replace(':','_').replace('/','_')[:64]
             fn = tmp
             ix = 1
             while fn in seen:


### PR DESCRIPTION
## How to reproduce
1. Create a note with a title that contains `:` character
2. Convert that note to html

## Expected
Resulting filename should not have any `/` character

## Actual Result
Resulting filename still has `/` characters

## Example 
This title
```
https://docs.google.com/spreadsheets
```

Will be converted to
```
https/__docs.google.com_spreadsheets
```
